### PR TITLE
Add repeating football background

### DIFF
--- a/journeyman/src/index.css
+++ b/journeyman/src/index.css
@@ -5,6 +5,10 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  background-color: #013369;
+  background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPSc2MCcgaGVpZ2h0PSc0MCcgdmlld0JveD0nMCAwIDYwIDQwJz48ZWxsaXBzZSBjeD0nMzAnIGN5PScyMCcgcng9JzI4JyByeT0nMTgnIGZpbGw9J25vbmUnIHN0cm9rZT0nd2hpdGUnIHN0cm9rZS13aWR0aD0nMicvPjxsaW5lIHgxPScxMicgeTE9JzIwJyB4Mj0nNDgnIHkyPScyMCcgc3Ryb2tlPSd3aGl0ZScgc3Ryb2tlLXdpZHRoPScyJy8+PGxpbmUgeDE9JzIyJyB5MT0nMTUnIHgyPScyMicgeTI9JzI1JyBzdHJva2U9J3doaXRlJyBzdHJva2Utd2lkdGg9JzInLz48bGluZSB4MT0nMzAnIHkxPScxNScgeDI9JzMwJyB5Mj0nMjUnIHN0cm9rZT0nd2hpdGUnIHN0cm9rZS13aWR0aD0nMicvPjxsaW5lIHgxPSczOCcgeTE9JzE1JyB4Mj0nMzgnIHkyPScyNScgc3Ryb2tlPSd3aGl0ZScgc3Ryb2tlLXdpZHRoPScyJy8+PC9zdmc+");
+  background-repeat: repeat;
+  background-size: 60px 40px;
 }
 
 code {


### PR DESCRIPTION
## Summary
- add repeating football outline background to the body style in `index.css`

## Testing
- `npm test --silent -- --watchAll=false` *(fails: Unable to find an element with the text: /learn react/i)*

------
https://chatgpt.com/codex/tasks/task_e_6840b0eeefdc832aae39d6a218ce9b7d