### PR TITLE
feat: add modal consent and session tracking

### DIFF
--- a/journeyman/src/App.test.js
+++ b/journeyman/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders welcome message', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/Welcome to Journeyman/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/journeyman/src/components/Modal.css
+++ b/journeyman/src/components/Modal.css
@@ -1,0 +1,25 @@
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-card {
+  background: #ffffff;
+  padding: 2rem;
+  border-radius: 8px;
+  max-width: 90%;
+  width: 400px;
+  text-align: center;
+}
+
+.modal-buttons {
+  margin-top: 1.5rem;
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+}

--- a/journeyman/src/components/Modal.js
+++ b/journeyman/src/components/Modal.js
@@ -1,0 +1,42 @@
+import React, { useEffect, useRef } from 'react';
+import './Modal.css';
+
+export default function Modal({ title, message, buttons = [], onClose }) {
+  const firstButtonRef = useRef(null);
+
+  useEffect(() => {
+    firstButtonRef.current?.focus();
+    const handleKey = (e) => {
+      if (e.key === 'Escape') {
+        onClose && onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [onClose]);
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div
+        className="modal-card"
+        role="dialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {title && <h2>{title}</h2>}
+        {typeof message === 'string' ? <p>{message}</p> : message}
+        <div className="modal-buttons">
+          {buttons.map((btn, i) => (
+            <button
+              key={i}
+              ref={i === 0 ? firstButtonRef : null}
+              onClick={btn.onClick}
+            >
+              {btn.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/journeyman/src/hooks/useOneTrust.js
+++ b/journeyman/src/hooks/useOneTrust.js
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+
+export default function useOneTrust() {
+  const [consentGranted, setConsentGranted] = useState(false);
+
+  useEffect(() => {
+    const domainId = process.env.REACT_APP_ONETRUST_ID || 'YOUR_DOMAIN_ID';
+    const script = document.createElement('script');
+    script.src = `https://cdn.cookielaw.org/consent/${domainId}/otSDKStub.js`;
+    script.setAttribute('data-domain-script', domainId);
+    script.async = true;
+    document.body.appendChild(script);
+
+    const checkConsent = () => {
+      const groups = window.OptanonActiveGroups || '';
+      setConsentGranted(groups.includes('C0002'));
+    };
+
+    window.OptanonWrapper = checkConsent;
+    script.onload = checkConsent;
+
+    return () => {
+      delete window.OptanonWrapper;
+    };
+  }, []);
+
+  const Overlay = () =>
+    consentGranted ? null : (
+      <div
+        style={{
+          position: 'fixed',
+          inset: 0,
+          background: 'rgba(0,0,0,0.8)',
+          color: '#fff',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          zIndex: 2000,
+          textAlign: 'center',
+          padding: '1rem',
+        }}
+      >
+        Please accept analytics cookies to play.
+      </div>
+    );
+
+  return { consentGranted, Overlay };
+}

--- a/journeyman/src/utils/logEvent.js
+++ b/journeyman/src/utils/logEvent.js
@@ -1,0 +1,11 @@
+const eventQueue = [];
+
+export function logEvent(name, data = {}) {
+  eventQueue.push({ name, data, timestamp: Date.now() });
+}
+
+export function flushEvents() {
+  const events = [...eventQueue];
+  eventQueue.length = 0;
+  return events;
+}


### PR DESCRIPTION
## Summary
- add reusable Modal component
- integrate OneTrust consent gating and event logger
- add start-game and complete-game session endpoints

## Testing
- `npm test -- --watchAll=false`
- `node --check journeyman/backend/server.js`


------
https://chatgpt.com/codex/tasks/task_e_68923be1244c832a983441c2f18b2c24